### PR TITLE
fix for CVE-2022-21680

### DIFF
--- a/src/rules.js
+++ b/src/rules.js
@@ -25,7 +25,7 @@ const block = {
     + '|<(?!script|pre|style|textarea)([a-z][\\w-]*)(?:attribute)*? */?>(?=[ \\t]*(?:\\n|$))[\\s\\S]*?(?:(?:\\n *)+\\n|$)' // (7) open tag
     + '|</(?!script|pre|style|textarea)[a-z][\\w-]*\\s*>(?=[ \\t]*(?:\\n|$))[\\s\\S]*?(?:(?:\\n *)+\\n|$)' // (7) closing tag
     + ')',
-  def: /^ {0,3}\[(label)\]: *\n? *<?([^\s>]+)>?(?:(?: +\n? *| *\n *)(title))? *(?:\n+|$)/,
+  def: /^ {0,3}\[(label)\]: *(?:\n *)?<?([^\s>]+)>?(?:(?: +(?:\n *)?| *\n *)(title))? *(?:\n+|$)/,
   table: noopTest,
   lheading: /^([^\n]+)\n {0,3}(=+|-+) *(?:\n+|$)/,
   // regex template, placeholders will be replaced according to different paragraph
@@ -34,7 +34,7 @@ const block = {
   text: /^[^\n]+/
 };
 
-block._label = /(?!\s*\])(?:\\[\[\]]|[^\[\]])+/;
+block._label = /(?!\s*\])(?:\\.|[^\[\]\\])+/;
 block._title = /(?:"(?:\\"?|[^"\\])*"|'[^'\n]*(?:\n[^'\n]+)*\n?'|\([^()]*\))/;
 block.def = edit(block.def)
   .replace('label', block._label)

--- a/test/specs/redos/cubic_def.cjs
+++ b/test/specs/redos/cubic_def.cjs
@@ -1,0 +1,4 @@
+module.exports = {
+  markdown: `[x]:${' '.repeat(1500)}x ${' '.repeat(1500)} x`,
+  html: `<p>[x]:${' '.repeat(1500)}x ${' '.repeat(1500)} x</p>`,
+};


### PR DESCRIPTION
This PR fixes a high-severity ReDoS (CVE-2022-21680) by hardening marked’s reference-definition parsing to prevent catastrophic regex backtracking. It replaces the vulnerable block.def/label regexes in src/rules.js with stricter patterns. Adds redos regression tests (test/specs/redos/cubic_def.*) and recommends upgrading to marked >= 4.0.10.

### Details
<table width="100%" border="0" cellpadding="8" cellspacing="0">
  <colgroup>
    <col width="20%">
    <col width="80%">
  </colgroup>
  <thead>
    <tr>
      <th align="left">Field</th>
      <th align="left">Description</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td valign="top">CVE ID</td>
      <td valign="top">CVE-2022-21680</td>
    </tr>
    <tr>
      <td valign="top">Severity</td>
      <td valign="top">High</td>
    </tr>
    <tr>
      <td valign="top">Summary</td>
      <td valign="top">
        Marked is a markdown parser and compiler. Prior to version 4.0.10, the regular expression `block.def` may cause catastrophic backtracking against some strings and lead to a regular expression denial of service (ReDoS). Anyone who runs untrusted markdown through a vulnerable version of marked and does not use a worker with a time limit may be affected. This issue is patched in version 4.0.10. As a workaround, avoid running untrusted markdown through marked or run marked on a worker thread and set a reasonable time limit to prevent draining resources.
      </td>
    </tr>
  </tbody>
</table>
