### PR TITLE
Add fix for CVE-2022-21680

### DIFF
--- a/src/rules.js
+++ b/src/rules.js
@@ -25,7 +25,7 @@ const block = {
     + '|<(?!script|pre|style|textarea)([a-z][\\w-]*)(?:attribute)*? */?>(?=[ \\t]*(?:\\n|$))[\\s\\S]*?(?:(?:\\n *)+\\n|$)' // (7) open tag
     + '|</(?!script|pre|style|textarea)[a-z][\\w-]*\\s*>(?=[ \\t]*(?:\\n|$))[\\s\\S]*?(?:(?:\\n *)+\\n|$)' // (7) closing tag
     + ')',
-  def: /^ {0,3}\[(label)\]: *\n? *<?([^\s>]+)>?(?:(?: +\n? *| *\n *)(title))? *(?:\n+|$)/,
+  def: /^ {0,3}\[(label)\]: *(?:\n *)?<?([^\s>]+)>?(?:(?: +(?:\n *)?| *\n *)(title))? *(?:\n+|$)/,
   table: noopTest,
   lheading: /^([^\n]+)\n {0,3}(=+|-+) *(?:\n+|$)/,
   // regex template, placeholders will be replaced according to different paragraph
@@ -34,7 +34,7 @@ const block = {
   text: /^[^\n]+/
 };
 
-block._label = /(?!\s*\])(?:\\[\[\]]|[^\[\]])+/;
+block._label = /(?!\s*\])(?:\\.|[^\[\]\\])+/;
 block._title = /(?:"(?:\\"?|[^"\\])*"|'[^'\n]*(?:\n[^'\n]+)*\n?'|\([^()]*\))/;
 block.def = edit(block.def)
   .replace('label', block._label)

--- a/test/specs/redos/cubic_def.cjs
+++ b/test/specs/redos/cubic_def.cjs
@@ -1,0 +1,4 @@
+module.exports = {
+  markdown: `[x]:${' '.repeat(1500)}x ${' '.repeat(1500)} x`,
+  html: `<p>[x]:${' '.repeat(1500)}x ${' '.repeat(1500)} x</p>`,
+};


### PR DESCRIPTION
This PR fixes a high severity vulnerability (CVE-2022-21680) by hardening marked’s reference-definition parsing to prevent catastrophic regex backtracking. It replaces the vulnerable block.def/label regexes with stricter patterns.

### Details

| **Field**              | **Description**                                                                                                                                          |
|------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
| **CVE ID**             | CVE-2022-21680                                                                                       |
| **Severity**           | High                                                                                                                                                     |
| **Summary**            | Marked is a markdown parser and compiler. Prior to version 4.0.10, the regular expression </br>`block.def` may cause catastrophic backtracking against some strings and lead to a regular </br>expression denial of service (ReDoS). Anyone who runs untrusted markdown through a </br>vulnerable version of marked and does not use a worker with a time limit may be affected. |

